### PR TITLE
 Add Alpine-based dev container with xa65 installed

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/devcontainers/base:alpine
+
+# Configurable version of xa65 assembler
+# (See: https://www.floodgap.com/retrotech/xa/dists/)
+ARG XA_VERSION=2.4.1
+
+# Build and install xa65 assembler from source
+WORKDIR /tmp
+RUN wget https://www.floodgap.com/retrotech/xa/dists/xa-${XA_VERSION}.tar.gz \
+    && tar -xzf xa-${XA_VERSION}.tar.gz \
+    && cd xa-${XA_VERSION} \
+    && make \
+    && make install PREFIX=/usr/local \
+    && cd / \
+    && rm -rf /tmp/xa-${XA_VERSION}*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "CBM Burnin Tests",
+
+	// Use Dockerfile for custom Alpine image with xa65 assembler
+	"dockerFile": "Dockerfile",
+
+	// Install extension for Makefile support
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.makefile-tools"
+			]
+		}
+	},
+
+	// Connect as the vscode user (non-root)
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
This PR adds a basic Alpine-based development container that comes preconfigured with all necessary build tools (including xa65).

